### PR TITLE
Add support for connecting directly to AnalyserNode

### DIFF
--- a/packages/wawa-lipsync/src/lipsync.ts
+++ b/packages/wawa-lipsync/src/lipsync.ts
@@ -102,6 +102,20 @@ export class Lipsync {
     this.analyser.connect(this.audioContext.destination);
   }
 
+  // Connect an existing AnalyserNode
+  connectAnalyser(analyser: AnalyserNode) {
+    this.analyser = analyser;
+    this.audioContext = analyser.context as AudioContext;
+    
+    this.sampleRate = this.audioContext.sampleRate;
+    this.binWidth = this.sampleRate / analyser.fftSize;
+    this.dataArray = new Uint8Array(analyser.frequencyBinCount);
+    
+    this.history = [];
+    this.features = null;
+    this.state = FSMStates.silence;
+  }
+
   // Connect live microphone
   async connectMicrophone() {
     try {


### PR DESCRIPTION
Passing an `AnalyserNode` that's owned by the caller is helpful when working with Web Audio, so I added a simple `connectAnalyser` signature to the Lipsync class

Want to confirm this doesn't break any lifecycle expectations though